### PR TITLE
[updated] change nan version ~2.1.0 -> ~2.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Get a specific usb device path for windows using pid and vid.",
   "main": "./build/Release/usb_dev",
   "dependencies": {
-    "nan": "~2.1.0"
+    "nan": "~2.3.2"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
Electron v0.37.0 から JavaScript Engine V8.4.9 を使うようになりましたが、
win-usbdev で使用している nan v2.1.0 では V8.4.9 向けにビルドができないため、
新しい nan を使うように修正しました。

nan v2.3.2 でも、以前の JS Engine 向けのビルドを行えることは確認済みです。
